### PR TITLE
Bugfixes for OS X

### DIFF
--- a/deer
+++ b/deer
@@ -79,7 +79,7 @@ deer--mark-file-list()
     shift
 
     print -l -- "$@" \
-        | grep -Fx -B5 -A$DEER_HEIGHT -m1 -- "$MARKED" \
+        | grep -Fx -B5 -A$DEER_HEIGHT -- "$MARKED" \
         | perl -pe 'BEGIN{$name = shift}
                     if ($name."\n" eq $_) {
                         $_="-> $_"
@@ -134,6 +134,7 @@ deer-preview()
                             | awk '{print substr($0,1,16)}') \
                         <(<<< $FILES)                        \
                         <(<<< $PREVIEW)                      \
+                | sed 's/\// \/ /g'                          \
                 | column -t -s/                              \
                 | awk -v width=$COLUMNS '{print substr($0,1,width-1)}')"
     zle -M -- $OUTPUT


### PR DESCRIPTION
This is a workaround for the column bug and a difference in behavior of grep on OS X.
1. replace "/" delimiter with " / " via sed so that column doesn't see any columns as empty.
2. remove "-m1" flag from grep. grep on OS X wasn't showing the after context when given this flag. I didn't see any negative consequences of removing it, but then again I'm not sure I understand why it was there to start with. Shouldn't there only be one match anyway?

Everything seems to work ok for me on OS X 10.9 and Ubuntu 14.04 with these changes, but I bet I've missed something.
