### PR TITLE
Remove python dependency

### DIFF
--- a/deer
+++ b/deer
@@ -259,10 +259,7 @@ deer-get-relative()
 {
     local TMP
     TMP=${1:-${DEER_DIRNAME%/}/$DEER_BASENAME[$DEER_DIRNAME]}
-    TMP="`python -c '
-import sys, os
-print(os.path.relpath(sys.argv[1], sys.argv[2]))
-' $TMP ${DEER_STARTDIR:-$PWD}`"
+    TMP="`realpath --relative-to=${DEER_STARTDIR:-$PWD} $TMP`"
     print -R $TMP:q
 }
 


### PR DESCRIPTION
Why use python when this can be done with coreutils? :)

The context is that it's easier to package without it. (There's a similar issue with perl but I don't know how to replace that part, so just one step at a time for now.)

It's cool if you don't want this change. Or maybe you're specifically using python for some reason?