### PR TITLE
Replace slash with fraction slash instead of backslash in file previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ _These are the issues that I'm aware of, along with the reason for why
 I've decided not to fix them for now. If you think any of them is a
 dealbreaker, open a ticket on Github and I'll see what I can do._
 
-**Slashes are replaced with backslashes in file previews**
+**Slashes are replaced with fraction slashes in file previews**
 
 This is an ugly workaround, and the issue is with the way the output is
 formatted (slash is used as a separator for `paste(1)` and

--- a/deer
+++ b/deer
@@ -199,9 +199,9 @@ deer-refresh()
         if file $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] | grep -Fq text; then
             PREVIEW="--- Preview: ---"$'\n'$(head -n$DEER_HEIGHT $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME])
 
-            # Replace '/' with '\' to allow using it as a
+            # Replace '/' with '⁄' (fraction slash) to allow using it as a
             # paste(1)/column(1) separator.
-            PREVIEW=${PREVIEW//\//\\}
+            PREVIEW=${PREVIEW//\//⁄}
         else
             PREVIEW="--- Binary file, preview unavailable ---"
         fi


### PR DESCRIPTION
Because backslashes are presumably more common than fraction slashes, and the fraction slash looks more like a slash.

I apologize if this has already been considered before, I couldn't find anything with my rudimentary searches.