### PR TITLE
Refresh prompt after cd into folders

### DIFF
--- a/deer
+++ b/deer
@@ -424,6 +424,7 @@ deer-launch()
                 if [[ -d $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] && \
                       -x $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] ]]; then
                     cd -- $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME]
+                    zle --reset-prompt
                     deer-restore
                     break
                 fi

--- a/deer
+++ b/deer
@@ -235,6 +235,7 @@ deer-restore()
     region_highlight=()
     LBUFFER=$OLD_LBUFFER
     RBUFFER=$OLD_RBUFFER
+    zle reset-prompt
     zle redisplay
     zle -M ""
 }
@@ -424,7 +425,6 @@ deer-launch()
                 if [[ -d $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] && \
                       -x $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] ]]; then
                     cd -- $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME]
-                    zle --reset-prompt
                     deer-restore
                     break
                 fi


### PR DESCRIPTION
Hi Vifon,
It is a great plugin for zsh. I think it is very useful and convenient.
But I found that the **prompt does not refresh** after cd into folders via "c" or "C" key.
Here is the snapshot for:
![old_behavior](https://user-images.githubusercontent.com/51704722/72162832-9d7a4580-33fd-11ea-837a-5a071c067f2c.png)
After "chdir" using "c" ro "C" key, the result of "pwd" command shows that the working directory has already changed. But the **prompt does not change**, which is confusing.
So I refresh the prompt via command
`zle --reset-prompt`
Then here is the screenshot for new behavior:
![new_behavior](https://user-images.githubusercontent.com/51704722/72163126-3315d500-33fe-11ea-83e5-1101cc2a457e.png)

Reference: [zsh: refresh prompt after running zle widget](https://stackoverflow.com/questions/52325626/zsh-refresh-prompt-after-running-zle-widget)