### PR TITLE
Add e to force opening file with EDITOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ parentheses):
 * `chdir` (<kbd>c</kbd>) -- `cd` into the current directory and quit.
 * `chdir_selected` (<kbd>C</kbd>) -- `cd` into the selected directory and quit.
 * `rifle` (<kbd>r</kbd>) -- Run `rifle(1)` on the selected file.
+* `edit` (<kbd>e</kbd>) -- Run `$EDITOR` on the selected file (default to vim).
 
 To bind a function to a different key, add something like this to your
 `.zshrc`:

--- a/deer
+++ b/deer
@@ -48,6 +48,7 @@ function ()
   chdir               c    \
   chdir_selected      C    \
   rifle               r    \
+  edit                e    \
 
 
 # Select the Nth next file. Pass a negative argument for the previous file.
@@ -428,9 +429,16 @@ deer-launch()
                     break
                 fi
                 ;;
+            $DEER_KEYS[edit])
+                if [[ -f $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] ]]; then
+                    "${EDITOR:-vim}" $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME]
+                fi
+                ;;
             # See rifle(1) manpage (included with ranger(1)).
             $DEER_KEYS[rifle])
-                rifle $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME]
+                if [[ -f $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME] ]]; then
+                    rifle $DEER_DIRNAME/$DEER_BASENAME[$DEER_DIRNAME]
+                fi
                 ;;
             # Arrow keys
             $'\e')


### PR DESCRIPTION
Hi,

Sometimes I want to open a file with the editor which is not always what `rifle` will give to me.

I added a way to force edition with $EDITOR (which defaults to `vim` following what rifle does).
This is bound to <kbs>e</kbd> (following the behavior of `ranger`).

When running this command on a directory, vim shows it with its internal browser (netrw). I don't think that all editors can open a directory like that so I check if the selection is a regulal file before.

I added the same check on rifle command to avoid errors printed like in the following screenshot:

![bug2](https://user-images.githubusercontent.com/29063375/74093029-ca894900-4acc-11ea-9cf2-e139d2685efe.png)

Nice project, thank you for this work!